### PR TITLE
Check for existence of `defaults` before checking `has_key`

### DIFF
--- a/app/models/hiera/config_file.rb
+++ b/app/models/hiera/config_file.rb
@@ -12,7 +12,7 @@ class Hiera
     end
 
     def default_yaml_data?
-      defaults.has_key?("data_hash") && defaults["data_hash"] == "yaml_data"
+      defaults && defaults.has_key?("data_hash") && defaults["data_hash"] == "yaml_data"
     end
 
     def defaults


### PR DESCRIPTION
If `defaults` is `nil` (and it can be in a legal `hiera.yaml`),
do not attempt to use the `has_key` method on it.

Resolves #9.