### PR TITLE
Fix tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ cache:
   bundler: true
   yarn: true
 before_install:
+  - yes | gem update --system --force
   - gem install bundler
 install:
   - bundle install

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: ruby
 cache:
   bundler: true
   yarn: true
+before_install:
+  - gem install bundler
 install:
   - bundle install
   - yarn install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: ruby
+cache:
+  bundler: true
+  yarn: true
+install:
+  - bundle install
+  - yarn install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+dist: bionic
 cache:
   bundler: true
   yarn: true

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@
 8. run hdm:
 
 ```
-    export HDM__CONFIG_DIR="/etc/puppetlabs/code/environments"
+    export HDM__CONFIG_DIR="/etc/puppetlabs/code"
 
     export HDM__PUPPET_DB__ENABLED=true
     # If you are using a self signed certificate, you need to set:

--- a/app/models/hiera.rb
+++ b/app/models/hiera.rb
@@ -73,12 +73,12 @@ class Hiera
   private
     def content
       @content ||= YAML.load(
-        File.read(Pathname.new(Settings.config_dir).join(environment, "hiera.yaml"))
+        File.read(Pathname.new(Settings.config_dir).join("environments", environment, "hiera.yaml"))
       )
     end
 
     def data_path
-      Pathname.new(Settings.config_dir).join(environment, "data")
+      Pathname.new(Settings.config_dir).join("environments", environment, "data")
     end
 
     def config_file

--- a/test/integration/lookup_test.rb
+++ b/test/integration/lookup_test.rb
@@ -12,7 +12,7 @@ class LookupTest < ActiveSupport::TestCase
       only_explain_options = false
       # formar :s or :yaml
       renderer = Puppet::Network::FormatHandler.format(:s)
-    
+
       lookup_invocation = Puppet::Pops::Lookup::Invocation.new(scope, {}, {}, explain ? Puppet::Pops::Lookup::Explainer.new(explain_options, only_explain_options) : nil)
       begin
         # type = options.include?(:type) ? Puppet::Pops::Types::TypeParser.singleton.parse(options[:type], scope) : nil
@@ -30,18 +30,18 @@ class LookupTest < ActiveSupport::TestCase
 
   def generate_scope
     env_name = 'development'
-    env_dir = '/Users/fernandes/src/hdm/puppet/environments'
-    Puppet.settings[:vardir] = '/Users/fernandes/src/hdm/tmp'
-    Puppet.settings[:codedir] = '/Users/fernandes/src/hdm/puppet'
-    Puppet.settings[:confdir] = '/Users/fernandes/src/hdm/puppet'
-    Puppet.settings[:rundir] = '/Users/fernandes/src/hdm/puppet'
-    Puppet.settings[:logdir] = '/Users/fernandes/src/hdm/puppet'
+    env_dir = File.join(Settings.config_dir, 'environments')
+    Puppet.settings[:vardir] = Rails.root.join("tmp")
+    Puppet.settings[:codedir] = Settings.config_dir
+    Puppet.settings[:confdir] = Settings.config_dir
+    Puppet.settings[:rundir] = Settings.config_dir
+    Puppet.settings[:logdir] = Settings.config_dir
     env = Puppet::Node::Environment.create(env_name.to_sym, [File.join(env_dir, env_name, 'modules')])
     environments = Puppet::Environments::Directories.new(env_dir, [])
-  
+
     Puppet.override(:environments => environments, :current_environment => env) do
       node = Puppet::Node.new('testhost', :environment => env)
-      fact_file = '/Users/fernandes/src/hdm/puppet/testhost_facts.json'
+      fact_file = File.join(Settings.config_dir, 'testhost_facts.json')
       given_facts = Puppet::Util::Json.load(Puppet::FileSystem.read(fact_file, :encoding => 'utf-8'))
       node.fact_merge(Puppet::Node::Facts.new('me', given_facts))
       compiler = Puppet::Parser::Compiler.new(node)

--- a/test/models/environment_test.rb
+++ b/test/models/environment_test.rb
@@ -5,6 +5,10 @@ class EnvironmentTest < ActiveSupport::TestCase
     Settings.puppet_db.enabled = false
   end
 
+  teardown do
+    Settings.puppet_db.enabled = false
+  end
+
   test "list the environments" do
     assert_equal ['development', 'hdm', 'test'], Environment.all
   end

--- a/test/models/hiera/read_file_test.rb
+++ b/test/models/hiera/read_file_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class Hiera::ReadFileTest < ActiveSupport::TestCase
   test "full path" do
     file = Hiera::ReadFile.new(config_dir: config_dir, path: "role/%{::role}-%{::env}.yaml", facts: facts)
-    assert_equal "/Users/fernandes/src/hdm/test/fixtures/files/environments/development/data/role/hdm_test-development.yaml", file.full_path
+    assert_equal File.join(Settings.config_dir, "environments/development/data/role/hdm_test-development.yaml"), file.full_path
   end
 
   test "#exit? return false for non existing file" do


### PR DESCRIPTION
This makes all tests pass on my machine.

It includes fixes for #18.

As part of this I rolled back an earlier change regarding the `config_dir` setting. This is needed to find all files, not just the environment-specific ones. I suspect this will not be necessary anymore once #13 is resolved, but for now I found it better to create a clean slate from which further development can be based on more easily.