### PR TITLE
Fix numeric values

### DIFF
--- a/app/javascript/components/Editable.js
+++ b/app/javascript/components/Editable.js
@@ -74,8 +74,8 @@ function Editable({ classes, model, hierarchy, file, enqueueSnackbar }) {
           path: file.path,
           value: value
         },
-        dataType: "json",
         headers: {
+          'Accept': 'application/json',
           'X-CSRF-Token': (meta_csrf ? meta_csrf.content : null)
         }
       })
@@ -104,8 +104,8 @@ function Editable({ classes, model, hierarchy, file, enqueueSnackbar }) {
       data: {
         path: file.path,
       },
-      dataType: "json",
       headers: {
+        'Accept': 'application/json',
         'X-CSRF-Token': (meta_csrf ? meta_csrf.content : null)
       }
     })

--- a/app/models/hiera/read_file.rb
+++ b/app/models/hiera/read_file.rb
@@ -31,7 +31,7 @@ class Hiera
       value = content[key]
       return "true" if value == true
       return "false" if value == false
-      return value if value.is_a?(String)
+      return value if [String, Integer, Float].include?(value.class)
 
       value_string = value.to_yaml
       value_string.gsub!("---\n", '').gsub!(/^$\n/, '')

--- a/test/fixtures/files/environments/development/data/common.yaml
+++ b/test/fixtures/files/environments/development/data/common.yaml
@@ -1,5 +1,7 @@
 ---
 # noop_mode: true
+hdm::float: 0.1
+hdm::integer: 1
 psick::enable_firstrun: false
 psick::firstrun::linux_classes:
   hostname: common::hostname

--- a/test/models/hiera/read_file_test.rb
+++ b/test/models/hiera/read_file_test.rb
@@ -65,6 +65,16 @@ class Hiera::ReadFileTest < ActiveSupport::TestCase
     assert_equal key_as_string, file.content_for_key('psick::postfix::tp::resources_hash')
   end
 
+  test "#content_for_key returns integer as integer" do
+    file = Hiera::ReadFile.new(config_dir: config_dir, path: "common.yaml", facts: facts)
+    assert_equal 1, file.content_for_key('hdm::integer')
+  end
+
+  test "#content_for_key returns float as float" do
+    file = Hiera::ReadFile.new(config_dir: config_dir, path: "common.yaml", facts: facts)
+    assert_equal 0.1, file.content_for_key('hdm::float')
+  end
+
   test "#write_key goes fine" do
     path = Rails.root.join('test', 'fixtures', 'files', 'environments', 'development', 'data', 'nodes', 'writehost.yaml')
 

--- a/test/models/hiera_test.rb
+++ b/test/models/hiera_test.rb
@@ -63,7 +63,7 @@ class HieraTest < ActiveSupport::TestCase
     hiera = Hiera.new('development')
     expected_result = {
       "_all_keys" => [
-        "noop_mode", "psick::enable_firstrun", "psick::firstrun::linux_classes", "psick::postfix::tp::resources_hash", "psick::time::servers", "psick::timezone"
+        "hdm::float", "hdm::integer", "noop_mode", "psick::enable_firstrun", "psick::firstrun::linux_classes", "psick::postfix::tp::resources_hash", "psick::time::servers", "psick::timezone"
       ],
       "Eyaml hierarchy" =>
       [
@@ -71,7 +71,7 @@ class HieraTest < ActiveSupport::TestCase
         { path: "role/hdm_test-development.yaml", present: false, keys: [] },
         { path: "role/hdm_test.yaml",             present: true, keys: ["psick::firstrun::linux_classes"] },
         { path: "zone/internal.yaml",             present: false, keys: [] },
-        { path: "common.yaml",                    present: true, keys: ["psick::enable_firstrun", "psick::firstrun::linux_classes", "psick::time::servers", "psick::timezone", "psick::postfix::tp::resources_hash"] }
+        { path: "common.yaml",                    present: true, keys: ["hdm::float", "hdm::integer", "psick::enable_firstrun", "psick::firstrun::linux_classes", "psick::time::servers", "psick::timezone", "psick::postfix::tp::resources_hash"] }
       ]
     }
 


### PR DESCRIPTION
This should fix #11 by ensuring that both `Integer` and `Float` (is this even a thing in puppet?) values are handled correctly.

It also includes a fix for #28, because without that I could not be sure if the other changes worked correctly end-to-end.