### PR TITLE
Introduce "FakePuppetDB" server

### DIFF
--- a/app/models/environment.rb
+++ b/app/models/environment.rb
@@ -2,12 +2,7 @@ class Environment
   class NotFound < StandardError; end
 
   def self.all
-    if Settings.puppet_db.enabled
-      PuppetDBClient.environments
-    else
-      environments_full_path = Dir.glob(Pathname.new(Settings.config_dir).join("environments", "*"))
-      environments_full_path.map { |x| File.basename(x) }.sort!
-    end
+    PuppetDBClient.environments
   end
 
   def initialize(environment)

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -4,7 +4,6 @@ class Node
   attr_reader :host
 
   def self.all
-    return ["testhost"] unless Settings.puppet_db.enabled
     PuppetDBClient.nodes
   end
 
@@ -15,14 +14,6 @@ class Node
   end
 
   def facts(environment:)
-    return @facts if @facts
-
-    if Settings.puppet_db.enabled
-      @facts = PuppetDBClient.facts(certname: host, environment: environment)
-    else
-      @facts = YAML.load(
-        File.read(Pathname.new(Settings.config_dir).join("#{host}_facts.yaml"))
-      )
-    end
+    PuppetDBClient.facts(certname: host, environment: environment)
   end
 end

--- a/app/services/fake_puppet_db.rb
+++ b/app/services/fake_puppet_db.rb
@@ -1,0 +1,41 @@
+class FakePuppetDB
+  def call(env)
+    request = Rack::Request.new(env)
+    case request.path
+    when "/pdb/query/v4/environments"
+      environments
+    when "/pdb/query/v4/nodes"
+      nodes
+    when "/pdb/query/v4/facts"
+      facts(request.params["query"])
+    else
+      [404, {}, ["Not Found"]]
+    end
+  end
+
+  private
+
+  def environments
+    environments_full_path = Dir.glob(Pathname.new(Settings.config_dir).join("environments", "*"))
+    environments = environments_full_path.map { |x| File.basename(x) }.sort
+      .map { |e| {"name" => e} }
+    respond_with(environments)
+  end
+
+  def nodes
+    respond_with([{"certname" => "testhost"}])
+  end
+
+  def facts(query)
+    host = JSON.parse(query).find { |e| e.is_a?(Array) && e[1] == "certname" }[2]
+    facts = YAML.load(
+      File.read(Pathname.new(Settings.config_dir).join("#{host}_facts.yaml"))
+    )
+    response = facts.map { |k, v| {"name" => k, "value" => v} }
+    respond_with(response)
+  end
+
+  def respond_with(data)
+    [200, {"Content-Type" => "application/json"}, [data.to_json]]
+  end
+end

--- a/bin/fake_puppet_db
+++ b/bin/fake_puppet_db
@@ -1,0 +1,9 @@
+#!/usr/bin/env ruby
+# begin
+#   load File.expand_path('../spring', __FILE__)
+# rescue LoadError => e
+#   raise unless e.message.include?('spring')
+# end
+require_relative '../config/environment'
+
+Rack::Server.start(app: FakePuppetDB.new, Host: "localhost", Port: 8083)

--- a/config/initializers/config.rb
+++ b/config/initializers/config.rb
@@ -16,7 +16,7 @@ contract.rule(:config_dir) do
 end
 
 contract.rule(puppet_db: :server) do
-  if values[:puppet_db][:enabled] && !values[:puppet_db][:server]
+  if !values[:puppet_db] || !values[:puppet_db][:server]
     key.failure("You must set a value for PuppetDB Server")
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,3 +1,3 @@
 ---
 puppet_db:
-  enabled: false
+  server: "http://localhost:8083"

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,3 +1,1 @@
 ---
-puppet_db:
-  enabled: true

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,2 +1,4 @@
 ---
 config_dir: <%= Rails.root %>/test/fixtures/files
+puppet_db:
+  server: "http://localhost:8084"

--- a/test/services/puppet_db_client_test.rb
+++ b/test/services/puppet_db_client_test.rb
@@ -1,21 +1,7 @@
 require 'test_helper'
 
 class PuppetDBClientTest < ActiveSupport::TestCase
-  def teardown
-    Settings.puppet_db.enabled = false
-  end
-
-  test "default is disabled" do
-    refute Settings.puppet_db.enabled
-
-    assert_equal [], PuppetDBClient.nodes
-  end
-
   test "when enabled get nodes from PuppetDB" do
-    Settings.puppet_db.server = "http://localhost:32769"
-    Settings.puppet_db.enabled = true
-    assert Settings.puppet_db.enabled
-
     @commander = Minitest::Mock.new
     @commander.expect :request, puppetdb_data, ["nodes", nil, {}]
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,12 @@ require_relative '../config/environment'
 require 'rails/test_help'
 require 'minitest/mock'
 
+# Start FakePuppetDB-Server
+server_thread = Thread.new do
+  Rack::Server.start(app: FakePuppetDB.new, Host: "localhost", Port: 8084)
+end
+server_thread.join(1)
+
 class ActiveSupport::TestCase
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   fixtures :all
@@ -16,7 +22,7 @@ class ActiveSupport::TestCase
       File.unlink(path) if File.exist?(path)
     end
   end
-  
+
   def json
     JSON.parse(response.body)
   end


### PR DESCRIPTION
I had a hard time trying to get puppetdb running locally (and eventually gave up). So making it a hard requirement as #13 requests, worries me. Imho this would set the bar too high for new developers who want to hack on hdm.

Also, I am pretty sure you do not want to run a full fledged puppet(db) server suite during CI runs, or during testing in general.

That is why I tried to find a compromise and I think this could be it:

This PR removes the file-based alternative to puppetdb and moves the code into a "fake server". hdm will now always try to talk to a puppetdb server (so it satisfies #13), but a developer can opt-in to run the fake server instead and deliver responses taken from the local `puppet/` directory. Tests will start and use this fake server automatically.

This is just a proof-of-concept to get the discussion going. I would like to have feedback what you think of this proposal.