### PR TITLE
Use hiera defaults

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,21 @@
 class ApplicationController < ActionController::Base
+  rescue_from Hdm::Error, with: :show_error
+
+  private
+
+  def show_error(error)
+    render(
+      {
+        html: cell(
+          Reativo::Cell::Component,
+          error,
+          {
+            layout: Theme::Cell::Layout,
+            context: _run_options({ flash: flash, controller: self, component: "errors/Show", props: {error: error} })
+          }
+        ),
+        status: 500
+      }
+    )
+  end
 end

--- a/app/javascript/components/errors/Show.js
+++ b/app/javascript/components/errors/Show.js
@@ -1,0 +1,30 @@
+import { hot } from 'react-hot-loader/root'
+import React from 'react';
+
+import { wrapper } from "reativo"
+
+import Dialog from '@material-ui/core/Dialog';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogContentText from '@material-ui/core/DialogContentText';
+import DialogTitle from '@material-ui/core/DialogTitle';
+
+function Show({model, error, classes}) {
+  return (
+    <div>
+      <Dialog
+        open={true}
+        aria-labelledby="alert-dialog-title"
+        aria-describedby="alert-dialog-description"
+      >
+        <DialogTitle id="alert-dialog-title">{"HDM Error"}</DialogTitle>
+        <DialogContent>
+          <DialogContentText id="alert-dialog-description">
+            {error}
+          </DialogContentText>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+export default hot(wrapper(Show));

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -27,3 +27,20 @@ import theme from '../theme'
 
 import { setTheme } from 'reativo'
 setTheme(theme)
+
+// Monkey patch Turbolinks to render 403, 404 & 500 normally
+// See https://github.com/turbolinks/turbolinks/issues/179
+window.Turbolinks.HttpRequest.prototype.requestLoaded = function() {
+  return this.endRequest(function() {
+    var code = this.xhr.status;
+    if (200 <= code && code < 300 ||
+        code === 403 || code === 404 || code === 500) {
+      this.delegate.requestCompletedWithResponse(
+          this.xhr.responseText,
+          this.xhr.getResponseHeader("Turbolinks-Location"));
+    } else {
+      this.failed = true;
+      this.delegate.requestFailedWithStatusCode(code, this.xhr.responseText);
+    }
+  }.bind(this));
+};

--- a/app/models/hdm/error.rb
+++ b/app/models/hdm/error.rb
@@ -1,0 +1,11 @@
+module Hdm
+  class Error < ::StandardError
+    def initialize(msg_or_error)
+      if msg_or_error.is_a?(Exception)
+        super("#{msg_or_error.class}: #{msg_or_error}")
+      else
+        super
+      end
+    end
+  end
+end

--- a/app/models/hiera.rb
+++ b/app/models/hiera.rb
@@ -11,13 +11,13 @@ class Hiera
 
   def paths
     paths = {}
-    config_file.environments.each { |x| paths[x.name] = x.paths }
+    config_file.hierarchies.each { |x| paths[x.name] = x.paths }
     paths
   end
 
   def expected_facts
     expected_facts = []
-    config_file.environments.map { |x| expected_facts.concat(x.expected_facts) }
+    config_file.hierarchies.map { |x| expected_facts.concat(x.expected_facts) }
     expected_facts.sort.uniq
   end
 

--- a/app/models/hiera.rb
+++ b/app/models/hiera.rb
@@ -71,17 +71,11 @@ class Hiera
   end
 
   private
-    def content
-      @content ||= YAML.load(
-        File.read(Pathname.new(Settings.config_dir).join("environments", environment, "hiera.yaml"))
-      )
-    end
-
     def data_path
       Pathname.new(Settings.config_dir).join("environments", environment, "data")
     end
 
     def config_file
-      @config_file ||= ConfigFile.new(content)
+      @config_file ||= ConfigFile.new(Pathname.new(Settings.config_dir).join("environments", environment))
     end
 end

--- a/app/models/hiera/config_file.rb
+++ b/app/models/hiera/config_file.rb
@@ -2,8 +2,8 @@ class Hiera
   class ConfigFile
     attr_reader :content, :hierarchies
 
-    def initialize(content)
-      @content = content
+    def initialize(base_path)
+      @content = load_content(base_path)
       initialize_hierarchies
     end
 
@@ -20,6 +20,23 @@ class Hiera
     end
 
     private
+
+    def load_content(base_path)
+      full_path = base_path.join("hiera.yaml")
+      defaults = Puppet::Pops::Lookup::HieraConfigV5::DEFAULT_CONFIG_HASH
+      config = if File.exist?(full_path)
+                 parsed_file = YAML.load(File.read(full_path))
+                 unless parsed_file["version"] == 5
+                   raise Hdm::Error, "hdm needs your hiera.yaml configuration to be in the version 5 format. Please convert your config file(s) before using hdm."
+                 end
+                 parsed_file
+               else
+                 {}
+               end
+      defaults.merge(config)
+    rescue => error
+      raise Hdm::Error, error
+    end
 
     def initialize_hierarchies
       return @hierarchies = [] unless content.has_key?("hierarchy")

--- a/app/models/hiera/config_file.rb
+++ b/app/models/hiera/config_file.rb
@@ -1,10 +1,10 @@
 class Hiera
   class ConfigFile
-    attr_reader :content, :environments
+    attr_reader :content, :hierarchies
 
     def initialize(content)
       @content = content
-      initialize_environments
+      initialize_hierarchies
     end
 
     def version5?
@@ -19,9 +19,11 @@ class Hiera
       content["defaults"]
     end
 
-    def initialize_environments
-      return @environments = [] unless content.has_key?("hierarchy")
-      @environments = content['hierarchy'].map do |hierarchy|
+    private
+
+    def initialize_hierarchies
+      return @hierarchies = [] unless content.has_key?("hierarchy")
+      @hierarchies = content['hierarchy'].map do |hierarchy|
         default_data_hash = default_yaml_data? ? 'yaml_data' : nil
         Hierarchy.new(hierarchy: hierarchy, default_data_hash: default_data_hash)
       end

--- a/app/services/puppet_db_client.rb
+++ b/app/services/puppet_db_client.rb
@@ -52,6 +52,8 @@ module PuppetDBClient
         {}
       )
       response.data.map { |x| x["name"] }
+    rescue => e
+      raise Hdm::Error, e
     end
 
     def client

--- a/test/fixtures/files/environments/minimal/hiera.yaml
+++ b/test/fixtures/files/environments/minimal/hiera.yaml
@@ -1,0 +1,4 @@
+version: 5
+defaults:
+  datadir: data
+  data_hash: yaml_data

--- a/test/fixtures/files/environments/multiple_hierarchies/hiera.yaml
+++ b/test/fixtures/files/environments/multiple_hierarchies/hiera.yaml
@@ -1,0 +1,11 @@
+version: 5
+defaults:
+  datadir: data
+  data_hash: yaml_data
+
+hierarchy:
+  - name: "Per-datacenter business group data" # Uses custom facts.
+    path: "location/%{facts.whereami}/%{facts.group}.yaml"
+
+  - name: "Global business group data"
+    path: "groups/%{facts.group}.yaml"

--- a/test/fixtures/files/environments/v3/hiera.yaml
+++ b/test/fixtures/files/environments/v3/hiera.yaml
@@ -1,0 +1,6 @@
+backends:
+  - yaml
+hierarchy:
+  - nodes/%{::trusted.certname}
+  - common
+merge_behavior: native

--- a/test/models/environment_test.rb
+++ b/test/models/environment_test.rb
@@ -10,7 +10,16 @@ class EnvironmentTest < ActiveSupport::TestCase
   end
 
   test "list the environments" do
-    assert_equal ['development', 'hdm', 'test'], Environment.all
+    expected_environments = %w(
+      development
+      hdm
+      minimal
+      multiple_hierarchies
+      no_config
+      test
+      v3
+    )
+    assert_equal expected_environments, Environment.all
   end
 
   test "create development environment" do

--- a/test/models/hiera/config_file_test.rb
+++ b/test/models/hiera/config_file_test.rb
@@ -6,7 +6,7 @@ class Hiera::ConfigFileTest < ActiveSupport::TestCase
       config = Hiera::ConfigFile.new(hiera_file)
       assert config.version5?
       assert config.default_yaml_data?
-      assert config.environments.empty?
+      assert config.hierarchies.empty?
     end
 
     def hiera_file
@@ -26,7 +26,7 @@ class Hiera::ConfigFileTest < ActiveSupport::TestCase
       config = Hiera::ConfigFile.new(hiera_file)
       assert config.version5?
       assert config.default_yaml_data?
-      assert_equal 2, config.environments.size
+      assert_equal 2, config.hierarchies.size
     end
 
     def hiera_file

--- a/test/models/hiera/config_file_test.rb
+++ b/test/models/hiera/config_file_test.rb
@@ -1,50 +1,53 @@
 require 'test_helper'
 
 class Hiera::ConfigFileTest < ActiveSupport::TestCase
-  class Hiera::ConfigFileWithDefaultDataTest < ActiveSupport::TestCase
-    test "when only defaults, return the yaml paths" do
-      config = Hiera::ConfigFile.new(hiera_file)
-      assert config.version5?
-      assert config.default_yaml_data?
-      assert config.hierarchies.empty?
+  class Hiera::ConfigFileV3 < ActiveSupport::TestCase
+    test "does not support v3 config style" do
+      assert_raise Hdm::Error do
+        Hiera::ConfigFile.new(base_path)
+      end
     end
 
-    def hiera_file
-      YAML.load(
-        <<~EOF
-        version: 5
-        defaults:
-          datadir: data
-          data_hash: yaml_data
-        EOF
-      )
+    def base_path
+      Pathname.new(Settings.config_dir).join("environments", "v3")
+    end
+  end
+  class Hiera::ConfigFileNoYamlFilePresent < ActiveSupport::TestCase
+    test "uses defaults from puppet" do
+      config = Hiera::ConfigFile.new(base_path)
+      assert config.version5?
+      assert config.default_yaml_data?
+      assert_equal 1, config.hierarchies.size
+    end
+
+    def base_path
+      Pathname.new(Settings.config_dir).join("environments", "no_config")
     end
   end
 
-  class Hiera::ConfigFileWithSomeEnvironmentsTest < ActiveSupport::TestCase
+  class Hiera::ConfigFileMinimalIncompleteYamlFile < ActiveSupport::TestCase
+    test "merges with defaults from puppet" do
+      config = Hiera::ConfigFile.new(base_path)
+      assert config.version5?
+      assert config.default_yaml_data?
+      assert_equal 1, config.hierarchies.size
+    end
+
+    def base_path
+      Pathname.new(Settings.config_dir).join("environments", "minimal")
+    end
+  end
+
+  class Hiera::ConfigFileWithSomeHierarchiesTest < ActiveSupport::TestCase
     test "when only defaults, return the yaml paths" do
-      config = Hiera::ConfigFile.new(hiera_file)
+      config = Hiera::ConfigFile.new(base_path)
       assert config.version5?
       assert config.default_yaml_data?
       assert_equal 2, config.hierarchies.size
     end
 
-    def hiera_file
-      YAML.load(
-        <<~EOF
-        version: 5
-        defaults:
-          datadir: data
-          data_hash: yaml_data
-        
-        hierarchy:
-          - name: "Per-datacenter business group data" # Uses custom facts.
-            path: "location/%{facts.whereami}/%{facts.group}.yaml"
-        
-          - name: "Global business group data"
-            path: "groups/%{facts.group}.yaml"
-        EOF
-      )
+    def base_path
+      Pathname.new(Settings.config_dir).join("environments", "multiple_hierarchies")
     end
   end
 end


### PR DESCRIPTION
This is my attempt to solve #14.

First of all, as a prerequisite I added a generic `Hiera::Error` class. Exceptions of this type get caught by the controller and result in a styled error message being displayed to the user.

hdm will now throw such an error when it encounters v3-style configuration (i.e. `version` is missing in the config file or something other than `5`).

hdm will now also merge any configuration encountered with the defaults from puppet, just like hiera "version 5" does. Since hdm already depended on the `puppet` ruby gem, I used the constant from there. That means that if the defaults ever change, an update of the dependency might suffice to be up-to-date.

I also took the liberty to support a missing `hiera.yaml` file, even though @tuxmea said to throw an error in that case. But since the original description in the issue said, hiera supports this, I was unsure. In any case, it is easy to change this if needed.

Please note that in case of a missing `hiera.yaml` file it will use hiera v5 defaults. I am not sure if this actually matches hiera's behavior, but I am sure that v3 defaults do not make sense for hdm at all.

Please give this a spin and let me know what you think.