### PR TITLE
Add read-only flag #15

### DIFF
--- a/app/concepts/keys/operation/show.rb
+++ b/app/concepts/keys/operation/show.rb
@@ -6,6 +6,7 @@ module Keys::Operation
     step :node!
     step :node_data!
     step :nodes!
+    step :read_only!
 
     def model!(opts, params:, current_user:, **)
       opts[:model] = OpenStruct.new(
@@ -31,6 +32,11 @@ module Keys::Operation
 
     def nodes!(opts, params:, current_user:, **)
       opts[:view][:nodes] = Node.all
+    end
+
+    def read_only!(opts, params:, current_user:, **)
+      opts[:view][:read_only] = (Settings.read_only == true)
+      true
     end
   end
 end

--- a/app/javascript/components/DataEditor.js
+++ b/app/javascript/components/DataEditor.js
@@ -43,7 +43,7 @@ const styles = theme => ({
   }
 });
 
-function DataEditor({ classes, model, environment, node, data, keyData }) {
+function DataEditor({ classes, model, environment, node, data, keyData, readOnly }) {
   const [selectedKeys, setSelectedKeys] = useState(data._all_keys);
   const [searchString, setSearchString] = useState("");
 
@@ -88,7 +88,7 @@ function DataEditor({ classes, model, environment, node, data, keyData }) {
       </Grid>
       {model && (
         <Grid item xs={12} md={6}>
-          <ValueInspector model={model} data={data} keyData={keyData} />
+          <ValueInspector model={model} data={data} keyData={keyData} readOnly={readOnly} />
         </Grid>
       )}
     </Grid>

--- a/app/javascript/components/Editable.js
+++ b/app/javascript/components/Editable.js
@@ -41,7 +41,7 @@ const styles = theme => ({
   }
 });
 
-function Editable({ classes, model, hierarchy, file, enqueueSnackbar }) {
+function Editable({ classes, model, hierarchy, file, enqueueSnackbar, readOnly }) {
   const [defaultValue, setDefaultValue] = useState(file.value || '');
   const [value, setValue] = useState(file.value || '');
   const [present, setPresent] = useState(file.present || false);
@@ -156,15 +156,20 @@ function Editable({ classes, model, hierarchy, file, enqueueSnackbar }) {
           className={classes.textField}
           margin="normal"
           variant="outlined"
+          disabled={readOnly}
         />
       </ExpansionPanelDetails>
       <Divider />
       <ExpansionPanelActions>
-        {(status() == "editablePresent") &&
+        {(status() == "editablePresent") && !readOnly &&
           <Button size="small" onClick={() => removeValue()} color="secondary">Remove Value</Button>
         }
-        <Button size="small" onClick={() => setValue(defaultValue)}>Cancel</Button>
-        <Button size="small" onClick={() => saveChanges(value)} color="primary">Save</Button>
+        { !readOnly &&
+          <Button size="small" onClick={() => setValue(defaultValue)}>Cancel</Button>
+        }
+        { !readOnly &&
+          <Button size="small" onClick={() => saveChanges(value)} color="primary">Save</Button>
+        }
       </ExpansionPanelActions>
     </ExpansionPanel>
   )

--- a/app/javascript/components/ValueInspector.js
+++ b/app/javascript/components/ValueInspector.js
@@ -19,7 +19,7 @@ const styles = theme => ({
   }
 });
 
-function ValueInspector({ classes, model, data, keyData }) {
+function ValueInspector({ classes, model, data, keyData, readOnly }) {
   return (
     <div className={classes.root}>
       {Object.keys(keyData).map(hierarchy => {
@@ -33,6 +33,7 @@ function ValueInspector({ classes, model, data, keyData }) {
                   key={`${hierarchy}-${file.path}`}
                   hierarchy={hierarchy}
                   file={file}
+                  readOnly={readOnly}
                 />
               );
             })}

--- a/app/javascript/components/keys/Show.js
+++ b/app/javascript/components/keys/Show.js
@@ -41,7 +41,8 @@ function Show({
   node,
   nodes,
   node_data,
-  key_data
+  key_data,
+  read_only
 }) {
   const handleEnvironmentChange = e =>
     Turbolinks.visit(`/environments/${e.target.value}`);
@@ -99,6 +100,7 @@ function Show({
         data={node_data}
         model={model}
         keyData={key_data}
+        readOnly={read_only}
       />
     </Grid>
   );

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,11 @@ Rails.application.routes.draw do
   resources :editor, only: [:index]
   resources :environments, only: [:show], id: /[^\/]+/ do
     resources :nodes, only: [:show], on: :member  do
-      resources :keys, only: [:show, :update, :create, :destroy], on: :member
+      if Settings.read_only
+        resources :keys, only: [:show], on: :member
+      else
+        resources :keys, only: [:show, :update, :create, :destroy], on: :member
+      end
     end
   end
   root to: "editor#index"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,3 +1,4 @@
 ---
+read_only: false
 puppet_db:
   server: "http://localhost:8083"

--- a/test/controllers/keys_controller_test.rb
+++ b/test/controllers/keys_controller_test.rb
@@ -47,6 +47,16 @@ class KeysControllerTest < ActionDispatch::IntegrationTest
     assert_equal ["specified value for key is not a valid YAML"], json["errors"]["value"]
   end
 
+  test "#update not possible in read-only mode" do
+    Settings.read_only = true
+    Rails.application.reload_routes!
+    assert_raise ActionController::RoutingError do
+      patch key_url('psick::enable_firstrun'), params: key_params, as: :json
+    end
+    Settings.read_only = false
+    Rails.application.reload_routes!
+  end
+
   test "#delete the key" do
     path = File.join(@role_dir, 'hdm_test.yaml')
 


### PR DESCRIPTION
This adds a new setting `read_only`. If set to `true`, form fields will be disabled and action buttons ("Save" etc.) hidden.

The actions to change key data are removed from the routing as well, so they cannot be accessed in any way.