### PR TITLE
Allow connecting to puppetdb via https.

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -102,8 +102,9 @@ Edit config file:
 
     development:
       read_only: false
-      puppet_db_server: "http://localhost:8080"
-      config_dir: <%= Rails.root.join('test','fixtures','files','puppet') %>
+      puppet_db:
+        server: "http://localhost:8080"
+      config_dir: "/etc/puppetlabs/code"
 
 Start the webserver with:
 

--- a/app/services/puppet_db_client.rb
+++ b/app/services/puppet_db_client.rb
@@ -1,22 +1,3 @@
-# if Settings.puppet_db.self_signed_cert
-#   require 'puppetdb/client'
-
-#   module PuppetDB
-#     class FixSSLConnectionAdapter < HTTParty::ConnectionAdapter
-#       def attach_ssl_certificates(http, options)
-#         if options[:pem].empty?
-#           http.ca_file = options[:cacert]
-#         else
-#           http.cert    = OpenSSL::X509::Certificate.new(File.read(options[:pem]['cert']))
-#           http.key     = OpenSSL::PKey::RSA.new(File.read(options[:pem]['key']))
-#           http.ca_file = options[:pem]['ca_file']
-#         end
-#         http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-#       end
-#     end
-#   end
-# end
-
 module PuppetDbClient
   module ClassMethods
     def nodes
@@ -57,12 +38,7 @@ module PuppetDbClient
     end
 
     def client
-      connection_hash = {
-        server: Rails.configuration.hdm["puppet_db_server"]
-      }
-
-      # connection_hash[:cacert] = Settings.puppet_db.ca_cert if Settings.puppet_db.ca_cert
-      # connection_hash[:token] = Settings.puppet_db.token if Settings.puppet_db.token
+      connection_hash = Rails.configuration.hdm["puppet_db"].with_indifferent_access
 
       PuppetDB::Client.new(connection_hash)
     end

--- a/config/hdm.yml.template
+++ b/config/hdm.yml.template
@@ -1,14 +1,34 @@
 development:
   read_only: false
-  puppet_db_server: "http://localhost:8083"
+  puppet_db:
+    server: "http://localhost:8083"
   config_dir: <%= Rails.root.join('test','fixtures','files','puppet') %>
 
 test:
   read_only: false
-  puppet_db_server: "http://localhost:8084"
+  puppet_db:
+    server: "http://localhost:8084"
   config_dir: <%= Rails.root.join('test','fixtures','files','puppet') %>
 
 production:
   read_only: false
-  puppet_db_server: "http://localhost:8083"
+  puppet_db:
+    # When using https make sure the server name matches
+    # the one in the certificate
+    server: "https://localhost:8081"
+    pem:
+      key: "/path/to/keyfile"
+      cert: "/path/to/certfile"
+      ca_file: "/path/to/cafile"
   config_dir: "/etc/puppetlabs/code"
+
+# Example for PE token authentication
+# production:
+#   read_only: false
+#   puppet_db:
+#     # When using https make sure the server name matches
+#     # the one in the certificate
+#     server: "https://localhost:8081"
+#     token: "secret_token"
+#     cacert: "/path/to/cacert"
+#   config_dir: "/etc/puppetlabs/code"


### PR DESCRIPTION
This makes the settings for puppetdb match the ones from the `puppetdb-ruby` gem as documented here:

https://github.com/voxpupuli/puppetdb-ruby/tree/v1.2.0#create-a-new-connection

Added all possible ways of configuring this to the config file template.

I successfully tested the token based authentication in the psick vagrant environment. I did _not_ test the cert based authentication against OS puppet, but see no reason why this would not work as it simply defers to the aforementioned gem.

This also completely removes the patch for the gem originally present in the old hdm. This patch completely disabled SSL verification. But I found SSL verification works just fine if you a) provide the correct CA certificate (generated by puppet) and b) use the same hostname as in the certificate (which is probably _not_ `localhost`).

Merging #76 and this would conclude #74 for me.