### PR TITLE
Support singular `path` setting in hierarchies #81

### DIFF
--- a/app/models/hiera_data/hierarchy.rb
+++ b/app/models/hiera_data/hierarchy.rb
@@ -31,7 +31,8 @@ class HieraData
     end
 
     def paths
-      @paths ||= raw_hash.fetch("paths", [])
+      @paths ||=
+        Array(raw_hash["path"] || raw_hash.fetch("paths", []))
     end
 
     def resolved_paths(facts:)

--- a/app/views/keys/show.html.erb
+++ b/app/views/keys/show.html.erb
@@ -7,8 +7,12 @@
   <div class="col-6">
     <% index = 0 %>
     <% @key.hierarchies.each do |hierarchy_name, paths| %>
-      <b><%= hierarchy_name %></b>
       <div class="accordion">
+        <div class="card">
+          <div class="card-body">
+            <b><%= hierarchy_name %></b>
+          </div>
+        </div>
         <% paths.each do |path_data| %>
           <% index += 1 %>
           <div class="card">

--- a/test/models/hiera_data/hierarchy_test.rb
+++ b/test/models/hiera_data/hierarchy_test.rb
@@ -1,6 +1,13 @@
 require 'test_helper'
 
 class HieraData::HierarchyTest < ActiveSupport::TestCase
+  test "#paths supports the singular `path` setting" do
+    path = "/test/singular/path"
+    raw_hash = {"name" => "Singular path", "path" => path}
+    hierarchy = HieraData::Hierarchy.new(raw_hash: raw_hash, base_path: ".")
+    assert_equal [path], hierarchy.paths
+  end
+
   test "#paths returns all non-interpolated path names" do
     hierarchy = HieraData::Hierarchy.new(raw_hash: raw_hash, base_path: ".")
     expected_paths = [


### PR DESCRIPTION
Up to now, hdm only supported hierarchies that used the plural `paths` settting in `hiera.yaml`.

This PR fixes that. It also includes a slight visual improvement to how multiple hierarchies are displayed.

Fixes #81.
