### PR TITLE
Fix typo preventing values to be displayed in read-only mode

### DIFF
--- a/app/views/keys/_form.html.erb
+++ b/app/views/keys/_form.html.erb
@@ -1,5 +1,5 @@
 <% if Rails.configuration.hdm['read_only'] %>
-  <pre><%= path_data["value"] %></pre>
+  <pre><%= path_data[:value] %></pre>
 <% else %>
   <%= form_with url: environment_node_key_path(@environment, @node, @key), method: :patch, local: true do |f| %>
     <%= hidden_field_tag :hierarchy, hierarchy %>


### PR DESCRIPTION
At some point hash access changed from string to symbol and I forgot to update this. Sorry.

This fixes #94