### PR TITLE
Improve display of file paths.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,4 +6,16 @@ module ApplicationHelper
       when 'alert' then "alert alert-warning"
     end
   end
+
+  def format_path(path_data)
+    tag_name, classes =
+      if path_data[:key_present]
+        [:b, nil]
+      elsif path_data[:file_present]
+        [:span, "text-dark"]
+      else
+        [:em, "text-muted"]
+      end
+    tag.send(tag_name, path_data[:path], class: classes)
+  end
 end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -9,7 +9,9 @@ Turbolinks.start()
 require("@rails/activestorage").start()
 require("channels")
 
-import "@fontsource/open-sans"
+import "@fontsource/open-sans/400.css"
+import "@fontsource/open-sans/400-italic.css"
+import "@fontsource/open-sans/700.css"
 
 import "bootstrap"
 import "../stylesheets/application"

--- a/app/models/hiera_data.rb
+++ b/app/models/hiera_data.rb
@@ -28,7 +28,7 @@ class HieraData
         file = YamlFile.new(path: hierarchy.datadir.join(path))
         search_results[hierarchy.name] << {
           path: path,
-          present: file.exist?,
+          file_present: file.exist?,
           key_present: file.keys.include?(key),
           value: file.content_for_key(key)
         }

--- a/app/views/keys/show.html.erb
+++ b/app/views/keys/show.html.erb
@@ -19,11 +19,7 @@
             <div class="card-header" id="path-<%= index %>">
               <h2 class="mb-0">
                 <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#collapse-<%= index %>" aria-expanded="true" aria-controls="collapse-<%= index %>">
-                  <% if path_data[:key_present] %>
-                    <b><%= path_data[:path] %></b>
-                  <% else %>
-                    <span class="text-muted"><%= path_data[:path] %></span>
-                  <% end %>
+                  <%= format_path(path_data) %>
                 </button>
               </h2>
             </div>

--- a/test/models/hiera_data_test.rb
+++ b/test/models/hiera_data_test.rb
@@ -15,11 +15,11 @@ class HieraDataTest < ActiveSupport::TestCase
     expected_result = {
       "Eyaml hierarchy" =>
       [
-        { path: "nodes/testhost.yaml",            present: true,  key_present: true, value: "hostname: hostname\n"  },
-        { path: "role/hdm_test-development.yaml", present: false,  key_present: false, value: nil  },
-        { path: "role/hdm_test.yaml",             present: true, key_present: true, value: "hostname: hostname-role\n" },
-        { path: "zone/internal.yaml",             present: false, key_present: false, value: nil },
-        { path: "common.yaml",                    present: true,  key_present: true, value: "hostname: common::hostname\n"  }
+        { path: "nodes/testhost.yaml",            file_present: true,  key_present: true, value: "hostname: hostname\n"  },
+        { path: "role/hdm_test-development.yaml", file_present: false,  key_present: false, value: nil  },
+        { path: "role/hdm_test.yaml",             file_present: true, key_present: true, value: "hostname: hostname-role\n" },
+        { path: "zone/internal.yaml",             file_present: false, key_present: false, value: nil },
+        { path: "common.yaml",                    file_present: true,  key_present: true, value: "hostname: common::hostname\n"  }
       ]
     }
 


### PR DESCRIPTION
See #90

With this, the correct font files for bold and italics are loaded as well so the browser does not have to calculate them. This especially improves the display of the bold paths for existing files.