### PR TITLE
Allow filtering of keys

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,4 +18,19 @@ module ApplicationHelper
       end
     tag.send(tag_name, path_data[:path], class: classes)
   end
+
+  def icon(name)
+    path = asset_pack_path("media/bootstrap-icons/bootstrap-icons.svg")
+    tag.svg(class: "bi", fill: "currentColor") do
+      tag.use(href: "#{path}##{name}")
+    end
+  end
+
+  def user_deletion_confirmation(user)
+    if user == current_user
+      'THIS IS YOUR ACCOUNT! Are you sure?'
+    else
+      'Are you sure?'
+    end
+  end
 end

--- a/app/javascript/controllers/key_filter_controller.js
+++ b/app/javascript/controllers/key_filter_controller.js
@@ -1,0 +1,29 @@
+import { Controller } from "stimulus"
+const Turbolinks = require("turbolinks")
+
+export default class extends Controller {
+  static targets = ["input", "keys"];
+
+  connect() {
+    this.filter();
+  }
+
+  filter() {
+    const search = this.inputTarget.value;
+    this.keysTargets.forEach( keyLink => {
+      if (search == "" || keyLink.innerText.indexOf(search) >= 0) {
+        keyLink.classList.remove("d-none");
+        const url = new URL(keyLink.href);
+        url.searchParams.set('search', search);
+        keyLink.href = url.toString();
+      } else {
+        keyLink.classList.add("d-none");
+      }
+    });
+  }
+
+  submit(event) {
+    event.stopPropagation();
+    event.preventDefault();
+  }
+}

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -17,7 +17,7 @@ import "@fontsource/open-sans/400-italic.css"
 import "@fontsource/open-sans/700.css"
 
 // Icons
-import "bootstrap-icons/icons/search.svg"
+import "bootstrap-icons/bootstrap-icons.svg"
 
 // Stylesheets
 import "bootstrap"

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -3,6 +3,7 @@
 // a relevant structure within app/javascript and only use these pack files to reference
 // that code so it'll be compiled.
 
+// JS Imports
 require("@rails/ujs").start()
 const Turbolinks = require("turbolinks")
 Turbolinks.start()
@@ -10,20 +11,20 @@ require("@rails/activestorage").start()
 require("channels")
 import "controllers"
 
+// Fonts
 import "@fontsource/open-sans/400.css"
 import "@fontsource/open-sans/400-italic.css"
 import "@fontsource/open-sans/700.css"
 
+// Icons
+import "bootstrap-icons/icons/search.svg"
+
+// Stylesheets
 import "bootstrap"
 import "../stylesheets/application"
 
+// Bootstrap JS Initialization
 document.addEventListener("turbolinks:load", () => {
   $('[data-toggle="tooltip"]').tooltip()
   $('[data-toggle="popover"]').popover()
 })
-// Uncomment to copy all static images under ../images to the output folder and reference
-// them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)
-// or the `imagePath` JavaScript helper below.
-//
-// const images = require.context('../images', true)
-// const imagePath = (name) => images(name, true)

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -19,3 +19,8 @@ ol.breadcrumb li:first-child {
 }
 
 @import "~slim-select/dist/slimselect";
+
+.bi {
+  width: 1em;
+  height: 1em;
+}

--- a/app/views/keys/_form.html.erb
+++ b/app/views/keys/_form.html.erb
@@ -7,10 +7,19 @@
     <%= text_area_tag :value, path_data[:value], rows: 4, class: "form-control" %>
     <div class="d-flex justify-content-end mt-2">
       <% if path_data[:key_present] %>
-        <%= link_to "Delete", environment_node_key_path(@environment, @node, @key, path: path_data[:path]), method: :delete, data: {confirm: "Are you sure?"}, class: "btn btn-sm btn-danger" %>
+        <%= link_to environment_node_key_path(@environment, @node, @key, path: path_data[:path]), method: :delete, data: {confirm: "Are you sure?"}, class: "btn btn-sm btn-danger" do %>
+          <%= icon "trash" %>
+          Delete
+        <% end %>
       <% end %>
-      <%= f.button "Reset", type: :reset, class: "btn btn-sm btn-secondary ml-2" %>
-      <%= f.button "Save", type: :submit, class: "btn btn-sm btn-primary ml-2" %>
+      <%= f.button type: :reset, class: "btn btn-sm btn-secondary ml-2" do %>
+        <%= icon "arrow-counterclockwise" %>
+        Reset
+      <% end %>
+      <%= f.button type: :submit, class: "btn btn-sm btn-primary ml-2" do %>
+        <%= icon "save" %>
+        Save
+      <% end %>
     </div>
   <% end %>
 <% end %>

--- a/app/views/keys/_key_list.html.erb
+++ b/app/views/keys/_key_list.html.erb
@@ -1,5 +1,17 @@
-<div class="list-group">
-  <% @keys.each do |key| %>
-    <%= link_to key, environment_node_key_path(@environment, @node, key), class: "list-group-item list-group-item-action #{"active" if key == @key}" %>
-  <% end %>
-</div>
+<form action="#" data-controller="key-filter" data-action="submit->key-filter#submit">
+  <div class="list-group">
+    <div class="list-group-item p-0">
+      <div class="input-group">
+        <div class="input-group-prepend">
+          <span class="input-group-text">
+            <%= image_pack_tag "media/icons/search.svg" %>
+          </span>
+        </div>
+        <%= text_field_tag :search, params[:search], class: "form-control", placeholder: "Search", data: {key_filter_target: "input", action: "keyup->key-filter#filter"} %>
+      </div>
+    </div>
+    <% @keys.each do |key| %>
+      <%= link_to key, environment_node_key_path(@environment, @node, key), class: "list-group-item list-group-item-action #{"active" if key == @key}", data: {key_filter_target: "keys"} %>
+    <% end %>
+  </div>
+</form>

--- a/app/views/keys/_key_list.html.erb
+++ b/app/views/keys/_key_list.html.erb
@@ -4,7 +4,7 @@
       <div class="input-group">
         <div class="input-group-prepend">
           <span class="input-group-text">
-            <%= image_pack_tag "media/icons/search.svg" %>
+            <%= icon "search" %>
           </span>
         </div>
         <%= text_field_tag :search, params[:search], class: "form-control", placeholder: "Search", data: {key_filter_target: "input", action: "keyup->key-filter#filter"} %>

--- a/app/views/page/index.html.erb
+++ b/app/views/page/index.html.erb
@@ -1,20 +1,7 @@
 <h1>HDM (Hiera Data Manager)</h1>
 <p>HDM is a webfrontend for visualizing and managing Hiera data.</p>
 <% unless current_user %>
-  <h2>Login</h2>
-  <%= form_tag sessions_path do |form| %>
-    <div class="form-group">
-      <%= label_tag :email %>
-      <%= text_field_tag :email, nil, class:"form-control", autofocus: true %>
-    </div>
-    <div class="form-group">
-      <%= label_tag :password %>
-      <%= password_field_tag :password, nil, class:"form-control" %>
-    </div>
-    <div class="actions">
-      <%= submit_tag "Login", class:"btn btn-success min-width-btn" %>
-    </div>
-  <% end %>
+  <%= render template: "sessions/new" %>
 <% else %>
   <% if User.count == 1 && current_user.admin? %>
     <h2>First Step: Create a User</h2>
@@ -24,9 +11,15 @@
     get access to the puppet configuration.</p>
   <% end %>
   <% if can? :index, Environment %>
-    <%= link_to "Show Environments", environments_path, class: "btn btn-primary" %>
+    <%= link_to environments_path, class: "btn btn-primary" do %>
+      <%= icon "list" %>
+      Show Environments
+    <% end %>
   <% end %>
   <% if can? :create, User %>
-    <%= link_to "Manage Users", users_path, class: "btn btn-primary" %>
+    <%= link_to users_path, class: "btn btn-primary" do %>
+      <%= icon "people" %>
+      Manage Users
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/roles/index.html.erb
+++ b/app/views/roles/index.html.erb
@@ -14,7 +14,10 @@
             <%= role.name %>
           </td>      
           <td>
-            <%= link_to 'Show', role, class:"btn btn-light min-width-btn" %>
+            <%= link_to role, class:"btn btn-sm btn-light min-width-btn" do %>
+              <%= icon "eye" %>
+              Show
+            <% end %>
           </td>
         </tr>
       <% end %>

--- a/app/views/roles/show.html.erb
+++ b/app/views/roles/show.html.erb
@@ -6,5 +6,8 @@
       <%= form.text_field :name ,class:"form-control", readonly:true%>
     </div>
   <% end %>
-  <%= link_to 'Back', roles_path,class:"btn btn-light min-width-btn" %>
+  <%= link_to roles_path, class:"btn btn-light min-width-btn" do %>
+    <%= icon "arrow-left-short" %>
+    Back
+  <% end %>
 </div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -9,7 +9,10 @@
     <%= password_field_tag :password, nil, class:"form-control" %>
   </div>
   <div class="actions">
-    <%= submit_tag "Login", class:"btn btn-success min-width-btn" %>
+    <%= button_tag class: "btn btn-primary min-width-btn" do %>
+      <%= icon("box-arrow-in-right") %>
+      Login
+    <% end %>
   </div>
 <% end %>
 

--- a/app/views/shared/_top_navigation.html.erb
+++ b/app/views/shared/_top_navigation.html.erb
@@ -10,19 +10,21 @@
         <% if current_user %>
           <li class="nav-item active dropdown">
             <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            <% if current_user %>
-              <%= current_user.email %>
-              <% if current_user.admin? %>
-                (<%= current_user.role %>)
-              <% end %>
-            <% else %>
-              Login
+            <%= current_user.email %>
+            <% if current_user.admin? %>
+              (<%= current_user.role %>)
             <% end %>
             </a>
             <div class="dropdown-menu" aria-labelledby="navbarDropdown">
               <% if current_user %>
-                <%= link_to 'Edit profile', edit_user_path(current_user), class: 'dropdown-item' %>
-                <%= link_to "Logout", logout_path, class: 'dropdown-item'  %>
+                <%= link_to edit_user_path(current_user), class: 'dropdown-item' do %>
+                  <%= icon "person" %>
+                  Edit Profile
+                <% end %>
+                <%= link_to logout_path, class: 'dropdown-item' do %>
+                  <%= icon "box-arrow-right" %>
+                  Logout
+                <% end %>
               <% else %>
                 <% if can? :create, User.new %>
                   <%= link_to "Sign up", signup_path, class: 'dropdown-item'  %>
@@ -31,16 +33,25 @@
               <% end %>
               <% if User.accessible_by(current_ability).any? %>
                 <div class="dropdown-divider"></div>
-                <%= link_to "List Users (#{User.accessible_by(current_ability).count})", users_path, class: 'dropdown-item'  %>
+                <%= link_to users_path, class: 'dropdown-item' do %>
+                  <%= icon "people" %>
+                  List Users (<%= User.accessible_by(current_ability).count %>)
+                <% end %>
                 <% if can? :create, User.new %>
-                  <%= link_to "Create a new User", new_user_path, class: 'dropdown-item'  %>
+                  <%= link_to new_user_path, class: 'dropdown-item' do %>
+                    <%= icon "person-plus" %>
+                    Create a new User
+                  <% end %>
                 <% end %>
               <% end %>
             </div>
           </li>
         <% else %>
           <li class="nav-item">
-            <%= link_to "Login", login_path, class: 'nav-link'  %>
+            <%= link_to login_path, class: 'nav-link' do %>
+              <%= icon "box-arrow-in-right" %>
+              Login
+            <% end %>
           </li>
         <% end %>
       </ul>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -35,6 +35,9 @@
     <% end %>
   <% end %>
   <div class="actions">
-    <%= form.submit "Save", class:"btn btn-success min-width-btn" %>
+    <%= form.button type: :submit, class:"btn btn-success min-width-btn" do %>
+      <%= icon "save" %>
+      Save
+    <% end %>
   </div>
 <% end %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -2,6 +2,12 @@
     <h1>Editing User</h1>
     <%= render 'form', user: @user %>
     <br>
-    <%= link_to 'Show', @user, class:"btn btn-light min-width-btn" %>
-    <%= link_to 'Back', users_path, class:"btn btn-light min-width-btn" %>
+    <%= link_to @user, class:"btn btn-light min-width-btn" do %>
+      <%= icon "eye" %>
+      Show
+    <% end %>
+    <%= link_to users_path, class:"btn btn-light min-width-btn" do %>
+      <%= icon "arrow-left-short" %>
+      Back
+    <% end %>
 </div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -31,16 +31,21 @@
           </td>      
           <td>
             <% if can? :show, user %>
-              <%= link_to 'Show', user, class:"btn btn-light min-width-btn" %>
+              <%= link_to user, class:"btn btn-sm btn-light min-width-btn" do %>
+                <%= icon "eye" %>
+                Show
+              <% end %>
             <% end %>
             <% if can? :edit, user %>
-              <%= link_to 'Edit', edit_user_path(user),class:"btn btn-primary min-width-btn"  %>     
+              <%= link_to edit_user_path(user), class:"btn btn-sm btn-primary min-width-btn" do %>
+                <%= icon "pencil" %>
+                Edit
+              <% end %>
             <% end %>
             <% if can? :delete, user %>
-              <% if user == current_user %>
-                <%= link_to 'Delete', user, method: :delete, data: { confirm: 'THIS IS YOUR ACCOUNT! Are you sure?' }, class:"btn btn-danger min-width-btn"%>
-              <% else %>
-                <%= link_to 'Delete', user, method: :delete, data: { confirm: 'Are you sure?' }, class:"btn btn-danger min-width-btn"%>
+              <%= link_to user, method: :delete, data: { confirm: user_deletion_confirmation(user) }, class:"btn btn-sm btn-danger min-width-btn" do %>
+                <%= icon "trash" %>
+                Delete
               <% end %>
             <% end %>
           </td>
@@ -50,6 +55,9 @@
   </table>
   <% if can? :create, User.new %>
     <br>
-    <%= link_to 'New User', new_user_path, class:"btn btn-success min-width-btn" %>
+    <%= link_to new_user_path, class:"btn btn-success min-width-btn" do %>
+      <%= icon "person-plus" %>
+      New User
+    <% end %>
   <% end %>
 </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -7,6 +7,9 @@
   <%= render 'form', user: @user %>
   <br>
   <% if User.any? %>
-    <%= link_to 'Back', users_path, class:"btn btn-light min-width-btn" %>
+    <%= link_to users_path, class:"btn btn-light min-width-btn" do %>
+      <%= icon "arrow-left-short" %>
+      Back
+    <% end %>
   <% end %>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -18,6 +18,12 @@
       <%= form.text_field :role ,class:"form-control", readonly:true%>
     </div>
   <% end %>
-  <%= link_to 'Edit', edit_user_path(@user),class:"btn btn-primary min-width-btn" %> 
-  <%= link_to 'Back', users_path,class:"btn btn-light min-width-btn" %>
+  <%= link_to edit_user_path(@user),class:"btn btn-primary min-width-btn" do %>
+    <%= icon "pencil" %>
+    Edit
+  <% end %>
+  <%= link_to users_path,class:"btn btn-light min-width-btn" do %>
+    <%= icon "arrow-left-short" %>
+    Back
+  <% end %>
 </div>

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "4.3.0",
     "bootstrap": "^4.5.3",
+    "bootstrap-icons": "^1.4.1",
     "jquery": "^3.5.1",
     "popper.js": "^1.16.1",
     "slim-select": "^1.27.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1643,6 +1643,11 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   resolved "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
+bootstrap-icons@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/bootstrap-icons/-/bootstrap-icons-1.4.1.tgz#5071d2ea9dab0ad79ca5673a97a0074872c74e14"
+  integrity sha512-EcATaAGsRgyy4NtnwXlNzkgWttpb6PqcXCoLtZZKdZtAYJU/WYqoQFxuGFKAppOlf7NmKpvGtSsC/921H7LIjg==
+
 bootstrap@^4.5.3:
   version "4.5.3"
   resolved "https://registry.npmjs.org/bootstrap/-/bootstrap-4.5.3.tgz"


### PR DESCRIPTION
This is a rough first version of key filtering. It might not be very efficient but worked fine in my (limited) tests. This should fix #92

To better set the search field apart visually (and to better explain it) I opted for a bootstrap input group with a search icon. To get the latter I included the bootstrap icon set (https://icons.getbootstrap.com).

Since we now had icons I did a small experiment and added other icons everywhere I thought they might work. This is in a seperate commit so could easily be reverted if it is not wanted.