### PR TITLE
Allow setting of a different hiera.yaml file.

### DIFF
--- a/app/models/hiera_data/config.rb
+++ b/app/models/hiera_data/config.rb
@@ -11,7 +11,7 @@ class HieraData
     private
 
     def load_content
-      full_path = @base_path.join("hiera.yaml")
+      full_path = @base_path.join(Rails.configuration.hdm["hiera_config_file"] || "hiera.yaml")
       defaults = Puppet::Pops::Lookup::HieraConfigV5::DEFAULT_CONFIG_HASH
       config = if File.exist?(full_path)
                  parsed_file = YAML.load(File.read(full_path))

--- a/config/hdm.yml.template
+++ b/config/hdm.yml.template
@@ -3,12 +3,14 @@ development:
   puppet_db:
     server: "http://localhost:8083"
   config_dir: <%= Rails.root.join('test','fixtures','files','puppet') %>
+  hiera_config_file: "hiera_hdm.yaml" # if not set, the default value 'hiera.yaml' is used
 
 test:
   read_only: false
   puppet_db:
     server: "http://localhost:8084"
   config_dir: <%= Rails.root.join('test','fixtures','files','puppet') %>
+  #hiera_config_file: "hiera_hdm.yaml"
 
 production:
   read_only: false
@@ -21,6 +23,7 @@ production:
       cert: "/path/to/certfile"
       ca_file: "/path/to/cafile"
   config_dir: "/etc/puppetlabs/code"
+  #hiera_config_file: "hiera_hdm.yaml"
 
 # Example for PE token authentication
 # production:
@@ -32,3 +35,4 @@ production:
 #     token: "secret_token"
 #     cacert: "/path/to/cacert"
 #   config_dir: "/etc/puppetlabs/code"
+#  hiera_config_file: "hiera_hdm.yaml"

--- a/test/fixtures/files/puppet/environments/multiple_hierarchies/hiera_hdm.yaml
+++ b/test/fixtures/files/puppet/environments/multiple_hierarchies/hiera_hdm.yaml
@@ -1,0 +1,18 @@
+version: 5
+defaults:
+  datadir: data
+  data_hash: yaml_data
+
+hierarchy:
+  - name: "Host specific"
+    path: "nodes/%{::fqdn}.yaml"
+
+  - name: "Per-datacenter business group data" # Uses custom facts.
+    paths:
+      - "role/%{::role}.yaml"
+      - "zone/%{::zone}.yaml"
+
+  - name: "Global data"
+    paths:
+      - "usermanagement.yaml"
+


### PR DESCRIPTION
If file does not exist, we assume no hiera.yaml config file is present
and we use hiera defaults.

fixes #105